### PR TITLE
Fix redirect stdout typo

### DIFF
--- a/boscli/filters.py
+++ b/boscli/filters.py
@@ -49,7 +49,7 @@ class RedirectStdout:
     '''
     def __init__(self, new_target):
         self.new_target = new_target
-        self.olt_target = None
+        self.old_target = None
 
     def __enter__(self):
         self.old_target = sys.stdout


### PR DESCRIPTION
## Summary
- fix attribute typo in `RedirectStdout`

## Testing
- `mamba --format documentation`

------
https://chatgpt.com/codex/tasks/task_e_68872f0e9eac8328a50f39248f42c3f5