### PR TITLE
Fix typo in ambiguous command error message

### DIFF
--- a/boscli/readlinecli/readlinecli.py
+++ b/boscli/readlinecli/readlinecli.py
@@ -107,7 +107,7 @@ class ReadlineCli:
                 print("No matching command found")
                 self._print_help(line)
             except exceptions.AmbiguousCommandError as exc:
-                print("Ambigous command")
+                print("Ambiguous command")
                 for command in exc.matching_commands:
                     print("\t", command)
             except (exceptions.EndOfProgram, EOFError, KeyboardInterrupt):


### PR DESCRIPTION
## Summary
- fix a typo in `readlinecli.py` error message

## Testing
- `python -m pip install -r requirements-dev.txt`
- `/root/.pyenv/versions/3.11.12/bin/mamba --enable-coverage .`


------
https://chatgpt.com/codex/tasks/task_e_68873985cfa48328a32298af67a7afd9