### PR TITLE
Fix RegexType partial_match context propagation

### DIFF
--- a/boscli/basic_types.py
+++ b/boscli/basic_types.py
@@ -134,4 +134,4 @@ class RegexType(BaseType):
         return not self.regex.match(word) is None
 
     def partial_match(self, word, context, partial_line=None):
-        return self.match(word, partial_line)
+        return self.match(word, context, partial_line)

--- a/spec/basic_types_spec.py
+++ b/spec/basic_types_spec.py
@@ -257,6 +257,23 @@ with describe('Basic Types'):
             assert_that(self.regex_type.partial_match('op3', self.context), is_(True))
             assert_that(self.regex_type.partial_match('op4', self.context), is_(False))
 
+        with it('propagates context and partial_line to match'):
+            class TestRegexType(basic_types.RegexType):
+                def __init__(self):
+                    super(TestRegexType, self).__init__('op[1-3]')
+                    self.recorded = None
+
+                def match(self, word, context, partial_line=None):
+                    self.recorded = (word, context, partial_line)
+                    return True
+
+            regex_type = TestRegexType()
+
+            result = regex_type.partial_match('op1', self.context, partial_line=['op'])
+
+            assert_that(result, is_(True))
+            assert_that(regex_type.recorded, is_(('op1', self.context, ['op'])))
+
         with context('Representation'):
             with it('has a default representation'):
                 assert_that(str(basic_types.RegexType('regEx')), contains_string('RegexType'))


### PR DESCRIPTION
## Summary
- ensure RegexType.partial_match forwards context and partial_line to match
- add regression spec validating correct propagation of context and partial line

## Testing
- `python -m pip install -r requirements-dev.txt`
- `/root/.pyenv/versions/3.11.12/bin/mamba`


------
https://chatgpt.com/codex/tasks/task_e_68ab81d7e4f08328bd4c1bdf65e65ffe