### PR TITLE
Drop Python 2 leftovers

### DIFF
--- a/boscli/basic_types.py
+++ b/boscli/basic_types.py
@@ -51,7 +51,7 @@ class OrType:
 
 class OptionsType(BaseType):
     def __init__(self, valid_options=None, name=None):
-        super(OptionsType, self).__init__()
+        super().__init__()
         self.name = name
         self.valid_options = valid_options or []
 
@@ -73,7 +73,7 @@ class OptionsType(BaseType):
         return self.valid_options
 
     def __str__(self):
-        if not self.name is None:
+        if self.name is not None:
             return '<%s>' % self.name
         return '<%s>' % ('|'.join(self.get_valid_options()))
 
@@ -89,7 +89,7 @@ class DynamicOptionsType(OptionsType):
 class StringType(BaseType):
 
     def __init__(self, name=None):
-        super(StringType, self).__init__(name)
+        super().__init__(name)
 
     def match(self, word, context, partial_line=None):
         return len(word) > 0
@@ -100,13 +100,13 @@ class StringType(BaseType):
 class BoolType(OptionsType):
 
     def __init__(self, name=None):
-        super(BoolType, self).__init__(['true', 'false'], name)
+        super().__init__(['true', 'false'], name)
 
 
 class IntegerType(BaseType):
 
     def __init__(self, min=None, max=None, name=None):
-        super(IntegerType, self).__init__(name)
+        super().__init__(name)
         self.min = min
         self.max = max
 
@@ -127,11 +127,11 @@ class IntegerType(BaseType):
 
 class RegexType(BaseType):
     def __init__(self, regex, name=None):
-        super(RegexType, self).__init__(name)
+        super().__init__(name)
         self.regex = re.compile(regex)
 
     def match(self, word, context, partial_line=None):
-        return not self.regex.match(word) is None
+        return self.regex.match(word) is not None
 
     def partial_match(self, word, context, partial_line=None):
         return self.match(word, context, partial_line)

--- a/boscli/command.py
+++ b/boscli/command.py
@@ -91,7 +91,7 @@ class Command:
         return True
 
     def context_match(self, context):
-        if self.always is True:
+        if self.always:
             return True
 
         if self.context_name and context.is_default():
@@ -122,7 +122,7 @@ class Command:
         return True
 
     def matching_parameters(self, tokens):
-        parameters=[]
+        parameters = []
         for index, token in enumerate(tokens):
             if not isinstance(self.keywords[index], str):
                 parameters.append(token)
@@ -166,7 +166,7 @@ class Command:
         return len(tokens) == len(self.keywords)
 
     def _select_token_to_complete(self, tokens):
-        if not len(tokens):
+        if not tokens:
             return (self.keywords[0], '')
         else:
             return (self.keywords[len(tokens) -1], tokens[-1])

--- a/boscli/exceptions.py
+++ b/boscli/exceptions.py
@@ -9,7 +9,7 @@ class NoMatchingCommandFoundError(EvalError):
 class AmbiguousCommandError(EvalError):
     def __init__(self, matching_commands):
         self.matching_commands = matching_commands
-        super(AmbiguousCommandError, self).__init__(matching_commands)
+        super().__init__(matching_commands)
 
 
 class SyntaxError(EvalError):

--- a/boscli/filters.py
+++ b/boscli/filters.py
@@ -25,7 +25,7 @@ class IncludeFilter(ByLineBaseFilter):
     def __init__(self, regex, stdout):
         self.regex = re.compile(regex)
         self.stdout = stdout
-        super(IncludeFilter, self).__init__()
+        super().__init__()
 
     def process_line(self, line):
         if self.regex.search(line):
@@ -36,7 +36,7 @@ class ExcludeFilter(ByLineBaseFilter):
     def __init__(self, regex, stdout):
         self.regex = re.compile(regex)
         self.stdout = stdout
-        super(ExcludeFilter, self).__init__()
+        super().__init__()
 
     def process_line(self, line):
         if not self.regex.search(line):

--- a/boscli/interpreter.py
+++ b/boscli/interpreter.py
@@ -23,7 +23,7 @@ class Context:
 
 class DefaultContext(Context):
     def __init__(self, prompt=None):
-        super(DefaultContext, self).__init__('Default', prompt=prompt)
+        super().__init__('Default', prompt=prompt)
 
     def is_default(self):
         return True

--- a/boscli/readlinecli/readlinecli.py
+++ b/boscli/readlinecli/readlinecli.py
@@ -5,11 +5,6 @@ import readline
 import atexit
 from boscli import exceptions
 
-try:
-    input = raw_input
-except NameError:
-    pass
-
 
 class ReadlineCli:
 
@@ -40,7 +35,7 @@ class ReadlineCli:
         histfile = os.path.expandvars(histfile)
         try:
             readline.read_history_file(histfile)
-        except IOError:
+        except OSError:
             pass
         atexit.register(self._save_history, histfile)
 

--- a/spec/basic_types_spec.py
+++ b/spec/basic_types_spec.py
@@ -260,7 +260,7 @@ with describe('Basic Types'):
         with it('propagates context and partial_line to match'):
             class TestRegexType(basic_types.RegexType):
                 def __init__(self):
-                    super(TestRegexType, self).__init__('op[1-3]')
+                    super().__init__('op[1-3]')
                     self.recorded = None
 
                 def match(self, word, context, partial_line=None):


### PR DESCRIPTION
## Summary
- remove raw_input fallback and catch OSError when loading history
- modernize classes and filters with super()
- simplify boolean and None checks across command and types

## Testing
- `mamba spec`

------
https://chatgpt.com/codex/tasks/task_e_68b6aef84f0c8328895836c37d87bbd7